### PR TITLE
Hu fr 001 update docs and fixs

### DIFF
--- a/prompts/coding-style-guide.md
+++ b/prompts/coding-style-guide.md
@@ -66,23 +66,72 @@ La estructura del proyecto está organizada por funcionalidad. Es crucial manten
 
 -   **Componentes Reutilizables:** Antes de crear un componente nuevo, revisa siempre la carpeta `src/components/shared`. Contiene elementos de UI genéricos (botones, modales, tablas, etc.) que deben ser utilizados para mantener la consistencia visual y funcional en toda la aplicación.
     -   **Notificaciones y Alertas:** Para mostrar mensajes de éxito o error al usuario, utiliza siempre los modales `SuccessModal` y `ErrorModal` que se encuentran en `@/app/components/shared/SuccessErrorModal`.
+
 ---
 
-## 5. Estilos y Temas
+## 5. Documentación de Componentes Compartidos
+
+A continuación se documentan los componentes compartidos más importantes. Es obligatorio usarlos para las funcionalidades que se describen.
+
+### 5.1. Modales de Notificación (`SuccessErrorModal.jsx`)
+
+Este archivo exporta tres componentes para manejar notificaciones al usuario: `SuccessModal`, `ErrorModal`, y `ConfirmModal`.
+
+-   **`SuccessModal`**: Muestra un mensaje de éxito.
+-   **`ErrorModal`**: Muestra un mensaje de error.
+-   **`ConfirmModal`**: Pide confirmación al usuario antes de una acción crítica (ej. eliminar un registro).
+
+-   **Props Principales (`SuccessModal`, `ErrorModal`):**
+    -   `isOpen`: Booleano para controlar la visibilidad.
+    -   `onClose`: Función para cerrar el modal.
+    -   `title`: (Opcional) El texto del título.
+    -   `message`: (Opcional) El cuerpo del mensaje.
+-   **Props Adicionales (`ConfirmModal`):**
+    -   `onConfirm`: Función que se ejecuta cuando el usuario confirma la acción.
+
+### 5.2. Tabla Genérica (`TableList.jsx`)
+
+Es un componente basado en `@tanstack/react-table` que renderiza una tabla con paginación, ordenamiento y filtro global. Se le debe pasar la configuración de las columnas y los datos a mostrar.
+
+-   **Props Principales:**
+    -   `columns`: Un array que define la estructura de las columnas (siguiendo el formato de TanStack Table).
+    -   `data`: El array de objetos a mostrar en la tabla.
+    -   `loading`: Un booleano para mostrar un indicador de carga mientras se obtienen los datos.
+
+### 5.3. Modal de Filtros (`FilterModal.jsx`)
+
+Proporciona una estructura base para un modal de filtros con botones de "Aplicar" y "Limpiar". Los campos y la lógica del filtro se le deben pasar como elementos hijos (`children`).
+
+-   **Props Principales:**
+    -   `open`: Booleano para controlar la visibilidad del modal.
+    -   `onClose`: Función para cerrar el modal.
+    -   `onApply`: Función que se ejecuta al presionar el botón "Aplicar".
+    -   `onClear`: Función que se ejecuta al presionar el botón "Limpiar".
+    -   `children`: Los componentes (inputs, selects, etc.) que conforman el formulario de filtro.
+
+### 5.4. Base para Modales y Diálogos (`@radix-ui/react-dialog`)
+
+Radix UI es la librería fundamental que utilizamos para construir cualquier tipo de modal o diálogo en la aplicación. Proporciona la base de accesibilidad y funcionalidad (manejo del foco, cierre con la tecla `Esc`, etc.), permitiéndonos construir sobre ella nuestros propios componentes estilizados, como el `FilterModal` o `ConfirmModal`.
+
+-   **Cuándo usarlo:** Siempre que necesites crear un nuevo componente de tipo modal que no se ajuste a los ya existentes (`SuccessModal`, `FilterModal`, etc.), debes usar Radix UI como base para asegurar la consistencia y accesibilidad.
+
+---
+
+## 6. Estilos y Temas
 
 -   **Tailwind CSS:** Utiliza las clases de utilidad de Tailwind CSS directamente en el atributo `className`. Evita usar valores arbitrarios (ej. `top-[13px]`).
 -   **Sistema de Temas:** Todos los componentes deben ser compatibles con el sistema de temas del proyecto. Utiliza las variables CSS definidas en `src/styles/theme.css` para colores, fuentes y otros aspectos visuales para asegurar que los componentes se adapten correctamente al tema activo.
 
 ---
 
-## 6. Manejo de Estado
+## 7. Manejo de Estado
 
 -   **Estado Local:** Usa el hook `useState` para el estado que solo afecta a un componente.
 -   **Estado Global:** Usa `useContext` para el estado que necesita ser compartido por múltiples componentes (ej. datos de usuario autenticado, tema de la aplicación). El `PermissionsContext` es el lugar central para gestionar los permisos y roles del usuario.
 
 ---
 
-## 7. Peticiones a la API (Services)
+## 8. Peticiones a la API (Services)
 
 -   **Toda la lógica de API debe estar en `src/services/`**. Los componentes no deben hacer llamadas a `axios` directamente.
 -   Cada archivo de servicio debe agrupar funciones relacionadas con un recurso de la API (ej. `authService.js`, `machineryService.js`).
@@ -120,14 +169,14 @@ La estructura del proyecto está organizada por funcionalidad. Es crucial manten
 
 ---
 
-## 8. Hooks Personalizados (`use...`)
+## 9. Hooks Personalizados (`use...`)
 
 -   Encapsula lógica compleja o reutilizable en hooks personalizados. Por ejemplo, `useAuth` es el lugar correcto para centralizar la lógica de `isAuthenticated`, `logout`, etc.
 -   **Mejora recomendada (`useAuth`):** El hook `useAuth` debe ser la única fuente de verdad sobre el estado de autenticación. Lógica como la decodificación del token o la comprobación de expiración que se encuentra en la página de login debería moverse a este hook o a un helper para ser reutilizada.
 
 ---
 
-## 9. Funciones de Utilidad (Utils)
+## 10. Funciones de Utilidad (Utils)
 
 -   Crea una carpeta `src/utils` para centralizar funciones puras y reutilizables que no son específicas de un componente o servicio.
 -   **Agrupa por dominio:** Organiza las utilidades en archivos según su funcionalidad.
@@ -151,14 +200,14 @@ La estructura del proyecto está organizada por funcionalidad. Es crucial manten
 
 ---
 
-## 10. Formularios
+## 11. Formularios
 
 -   Usa la librería `react-hook-form` para todos los formularios.
 -   Define las reglas de validación en el objeto que se pasa a la función `register`.
 
 ---
 
-## 11. Código Limpio
+## 12. Código Limpio
 
 -   **Elimina código no utilizado:** Antes de hacer commit, elimina `console.log`, comentarios de código antiguo y variables no utilizadas.
 -   **Comentarios:** Escribe comentarios solo para explicar lógica de negocio compleja o algoritmos que no son evidentes a simple vista. No comentes lo obvio.
@@ -166,7 +215,7 @@ La estructura del proyecto está organizada por funcionalidad. Es crucial manten
 
 ---
 
-## 12. Reglas Generales de Desarrollo
+## 13. Reglas Generales de Desarrollo
 
 -   **Idioma:** Todos los textos visibles para el usuario en la interfaz (labels, botones, mensajes de error, etc.) deben estar en **español**.
 -   **Accesibilidad y Pruebas:** Todo elemento interactivo (botones, enlaces, inputs, etc.) debe tener un atributo `aria-label` descriptivo. Esto es fundamental para la accesibilidad y facilita la creación de pruebas automatizadas.
@@ -175,7 +224,7 @@ La estructura del proyecto está organizada por funcionalidad. Es crucial manten
 
 ---
 
-## 13. Flujo de Trabajo con Git
+## 14. Flujo de Trabajo con Git
 
 -   **Nomenclatura de Ramas:** Para mantener un historial claro, las ramas deben seguir la siguiente convención:
     -   **Nuevas funcionalidades:** `feature/descripcion-corta-de-la-funcionalidad` (ej. `feature/login-con-google`)

--- a/src/app/components/machinery/history/HistoryFiltersModal.jsx
+++ b/src/app/components/machinery/history/HistoryFiltersModal.jsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from 'react'
-import * as Dialog from '@radix-ui/react-dialog'
-import { FaTimes, FaCalendarAlt } from 'react-icons/fa'
+import { FaCalendarAlt } from 'react-icons/fa'
+import FilterModal from '@/app/components/shared/FilterModal'
 
 const defaultFilters = {
   startDate: '',
@@ -44,116 +44,74 @@ const HistoryFiltersModal = ({
     }
   }
 
-  const handleOpenChange = (open) => {
-    if (!open && typeof onClose === 'function') {
-      onClose()
-    }
-  }
-
   return (
-    <Dialog.Root open={isOpen} onOpenChange={handleOpenChange}>
-      <Dialog.Portal>
-        <Dialog.Overlay className="fixed inset-0 bg-black/40 backdrop-blur-sm z-[60]" />
-        <Dialog.Content className="fixed top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 z-[70] w-full max-w-lg rounded-2xl card-theme">
-          <div className="p-6 space-y-6">
-            <div className="flex items-start justify-between">
-              <div>
-                <Dialog.Title className="text-xl font-semibold text-primary">Filtros</Dialog.Title>
-              </div>
-              <Dialog.Close asChild>
-                <button
-                  onClick={onClose}
-                  className="text-secondary hover:text-primary"
-                  aria-label="Cerrar filtros de historial"
-                >
-                  <FaTimes className="w-5 h-5" />
-                </button>
-              </Dialog.Close>
-            </div>
-
-            <div className="space-y-5">
-              <div className="space-y-3">
-                <span className="text-sm font-medium text-primary">Fecha de modificación</span>
-                <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
-                  <div className="flex flex-col gap-2">
-                    <label className="text-xs text-secondary uppercase tracking-wide">Inicio</label>
-                    <div className="relative">
-                      <input
-                        type="date"
-                        name="startDate"
-                        value={filters.startDate}
-                        onChange={handleInputChange}
-                        className="w-full rounded-lg border border-gray-200 py-2.5 pl-3 pr-10 text-sm focus:border-accent focus:outline-none focus:ring-2 focus:ring-accent/20"
-                        aria-label="Fecha de inicio"
-                      />
-                      <FaCalendarAlt className="absolute right-3 top-1/2 -translate-y-1/2 text-gray-400 w-4 h-4" />
-                    </div>
-                  </div>
-                  <div className="flex flex-col gap-2">
-                    <label className="text-xs text-secondary uppercase tracking-wide">Fin</label>
-                    <div className="relative">
-                      <input
-                        type="date"
-                        name="endDate"
-                        value={filters.endDate}
-                        onChange={handleInputChange}
-                        className="w-full rounded-lg border border-gray-200 py-2.5 pl-3 pr-10 text-sm focus:border-accent focus:outline-none focus:ring-2 focus:ring-accent/20"
-                        aria-label="Fecha de fin"
-                      />
-                      <FaCalendarAlt className="absolute right-3 top-1/2 -translate-y-1/2 text-gray-400 w-4 h-4" />
-                    </div>
-                  </div>
-                </div>
-              </div>
-
-              <div className="flex flex-col gap-2">
-                <label className="text-sm font-medium text-primary">Usuario responsable</label>
-                <select
-                  name="user"
-                  value={filters.user}
+    <FilterModal
+      open={isOpen}
+      onClose={onClose}
+      onApply={handleApply}
+      onClear={handleClear}
+    >
+      <div className="space-y-5">
+        <div className="space-y-3">
+          <span className="text-sm font-medium text-primary">Fecha de modificación</span>
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+            <div className="flex flex-col gap-2">
+              <label className="text-xs text-secondary uppercase tracking-wide">Inicio</label>
+              <div className="relative">
+                <input
+                  type="date"
+                  name="startDate"
+                  value={filters.startDate}
                   onChange={handleInputChange}
-                  disabled={loading || !!error}
-                  className="w-full rounded-lg border border-gray-200 py-2.5 px-3 text-sm focus:border-accent focus:outline-none focus:ring-2 focus:ring-accent/20 disabled:bg-gray-100 disabled:text-gray-400"
-                  aria-label="Seleccionar usuario responsable"
-                >
-                  <option value="">Todos</option>
-                  {users.map((user) => (
-                    <option key={user} value={user}>
-                      {user}
-                    </option>
-                  ))}
-                </select>
-                {loading && (
-                  <p className="text-xs text-secondary">Cargando usuarios...</p>
-                )}
-                {error && (
-                  <p className="text-xs text-red-500">{error}</p>
-                )}
+                  className="w-full rounded-lg border border-gray-200 py-2.5 pl-3 pr-10 text-sm focus:border-accent focus:outline-none focus:ring-2 focus:ring-accent/20"
+                  aria-label="Fecha de inicio"
+                />
+                <FaCalendarAlt className="absolute right-3 top-1/2 -translate-y-1/2 text-gray-400 w-4 h-4" />
               </div>
             </div>
-
-            <div className="flex flex-col sm:flex-row sm:justify-end gap-3 pt-2">
-              <button
-                type="button"
-                onClick={handleClear}
-                className="w-full sm:w-auto px-6 py-2.5 rounded-xl bg-error text-white text-sm font-semibold transition-colors hover:bg-error-hover"
-                aria-label="Limpiar filtros"
-              >
-                Limpiar
-              </button>
-              <button
-                type="button"
-                onClick={handleApply}
-                className="w-full sm:w-auto px-6 py-2.5 rounded-xl bg-primary text-white text-sm font-semibold transition-colors hover:bg-accent"
-                aria-label="Aplicar filtros"
-              >
-                Aplicar
-              </button>
+            <div className="flex flex-col gap-2">
+              <label className="text-xs text-secondary uppercase tracking-wide">Fin</label>
+              <div className="relative">
+                <input
+                  type="date"
+                  name="endDate"
+                  value={filters.endDate}
+                  onChange={handleInputChange}
+                  className="w-full rounded-lg border border-gray-200 py-2.5 pl-3 pr-10 text-sm focus:border-accent focus:outline-none focus:ring-2 focus:ring-accent/20"
+                  aria-label="Fecha de fin"
+                />
+                <FaCalendarAlt className="absolute right-3 top-1/2 -translate-y-1/2 text-gray-400 w-4 h-4" />
+              </div>
             </div>
           </div>
-        </Dialog.Content>
-      </Dialog.Portal>
-    </Dialog.Root>
+        </div>
+
+        <div className="flex flex-col gap-2">
+          <label className="text-sm font-medium text-primary">Usuario responsable</label>
+          <select
+            name="user"
+            value={filters.user}
+            onChange={handleInputChange}
+            disabled={loading || !!error}
+            className="w-full rounded-lg border border-gray-200 py-2.5 px-3 text-sm focus:border-accent focus:outline-none focus:ring-2 focus:ring-accent/20 disabled:bg-gray-100 disabled:text-gray-400"
+            aria-label="Seleccionar usuario responsable"
+          >
+            <option value="">Todos</option>
+            {users.map((user) => (
+              <option key={user} value={user}>
+                {user}
+              </option>
+            ))}
+          </select>
+          {loading && (
+            <p className="text-xs text-secondary">Cargando usuarios...</p>
+          )}
+          {error && (
+            <p className="text-xs text-red-500">{error}</p>
+          )}
+        </div>
+      </div>
+    </FilterModal>
   )
 }
 

--- a/src/app/components/machinery/history/MaintenanceFiltersModal.jsx
+++ b/src/app/components/machinery/history/MaintenanceFiltersModal.jsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from 'react'
-import * as Dialog from '@radix-ui/react-dialog'
-import { FaTimes, FaCalendarAlt } from 'react-icons/fa'
+import { FaCalendarAlt } from 'react-icons/fa'
+import FilterModal from '@/app/components/shared/FilterModal'
 
 const defaultFilters = {
   startDate: '',
@@ -44,125 +44,83 @@ const MaintenanceFiltersModal = ({
     }
   }
 
-  const handleOpenChange = (open) => {
-    if (!open && typeof onClose === 'function') {
-      onClose()
-    }
-  }
-
   return (
-    <Dialog.Root open={isOpen} onOpenChange={handleOpenChange}>
-      <Dialog.Portal>
-        <Dialog.Overlay className="fixed inset-0 bg-black/40 backdrop-blur-sm z-[60]" />
-        <Dialog.Content className="fixed top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 z-[70] w-full max-w-lg rounded-2xl card-theme">
-          <div className="p-6 space-y-6">
-            <div className="flex items-start justify-between">
-              <div>
-                <Dialog.Title className="text-xl font-semibold text-primary">Filtros</Dialog.Title>
-              </div>
-              <Dialog.Close asChild>
-                <button
-                  onClick={onClose}
-                  className="text-secondary hover:text-primary"
-                  aria-label="Cerrar filtros"
-                >
-                  <FaTimes className="w-5 h-5" />
-                </button>
-              </Dialog.Close>
-            </div>
-
-            <div className="space-y-5">
-              <div className="space-y-3">
-                <span className="text-sm font-medium text-primary">Fecha de solicitud</span>
-                <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
-                  <div className="flex flex-col gap-2">
-                    <label className="text-xs text-secondary uppercase tracking-wide">Inicio</label>
-                    <div className="relative">
-                      <input
-                        type="date"
-                        name="startDate"
-                        value={filters.startDate}
-                        onChange={handleInputChange}
-                        className="w-full rounded-lg border border-gray-200 py-2.5 pl-3 pr-10 text-sm focus:border-accent focus:outline-none focus:ring-2 focus:ring-accent/20"
-                        aria-label="Fecha de inicio"
-                      />
-                      <FaCalendarAlt className="absolute right-3 top-1/2 -translate-y-1/2 text-gray-400 w-4 h-4" />
-                    </div>
-                  </div>
-                  <div className="flex flex-col gap-2">
-                    <label className="text-xs text-secondary uppercase tracking-wide">Fin</label>
-                    <div className="relative">
-                      <input
-                        type="date"
-                        name="endDate"
-                        value={filters.endDate}
-                        onChange={handleInputChange}
-                        className="w-full rounded-lg border border-gray-200 py-2.5 pl-3 pr-10 text-sm focus:border-accent focus:outline-none focus:ring-2 focus:ring-accent/20"
-                        aria-label="Fecha de fin"
-                      />
-                      <FaCalendarAlt className="absolute right-3 top-1/2 -translate-y-1/2 text-gray-400 w-4 h-4" />
-                    </div>
-                  </div>
-                </div>
-              </div>
-
-              <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
-                <div className="flex flex-col gap-2">
-                  <label className="text-sm font-medium text-primary">Tipo de mantenimiento</label>
-                  <select
-                    name="maintenanceType"
-                    value={filters.maintenanceType}
-                    onChange={handleInputChange}
-                    className="w-full rounded-lg border border-gray-200 py-2.5 px-3 text-sm focus:border-accent focus:outline-none focus:ring-2 focus:ring-accent/20"
-                    aria-label="Seleccionar tipo de mantenimiento"
-                  >
-                    <option value="">Todos</option>
-                    {maintenanceTypes.map((type) => (
-                      <option key={type} value={type}>{type}</option>
-                    ))}
-                  </select>
-                </div>
-
-                <div className="flex flex-col gap-2">
-                  <label className="text-sm font-medium text-primary">Estado de la solicitud</label>
-                  <select
-                    name="status"
-                    value={filters.status}
-                    onChange={handleInputChange}
-                    className="w-full rounded-lg border border-gray-200 py-2.5 px-3 text-sm focus:border-accent focus:outline-none focus:ring-2 focus:ring-accent/20"
-                    aria-label="Seleccionar estado de la solicitud"
-                  >
-                    <option value="">Todos</option>
-                    {statuses.map((status) => (
-                      <option key={status} value={status}>{status}</option>
-                    ))}
-                  </select>
-                </div>
+    <FilterModal
+      open={isOpen}
+      onClose={onClose}
+      onApply={handleApply}
+      onClear={handleClear}
+    >
+      <div className="space-y-5">
+        <div className="space-y-3">
+          <span className="text-sm font-medium text-primary">Fecha de solicitud</span>
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+            <div className="flex flex-col gap-2">
+              <label className="text-xs text-secondary uppercase tracking-wide">Inicio</label>
+              <div className="relative">
+                <input
+                  type="date"
+                  name="startDate"
+                  value={filters.startDate}
+                  onChange={handleInputChange}
+                  className="w-full rounded-lg border border-gray-200 py-2.5 pl-3 pr-10 text-sm focus:border-accent focus:outline-none focus:ring-2 focus:ring-accent/20"
+                  aria-label="Fecha de inicio"
+                />
+                <FaCalendarAlt className="absolute right-3 top-1/2 -translate-y-1/2 text-gray-400 w-4 h-4" />
               </div>
             </div>
-
-            <div className="flex flex-col sm:flex-row sm:justify-end gap-3 pt-2">
-              <button
-                type="button"
-                onClick={handleClear}
-                className="w-full sm:w-auto px-6 py-2.5 rounded-xl bg-red-600 text-white text-sm font-semibold transition-colors hover:bg-red-700"
-                aria-label="Limpiar filtros"
-              >
-                Limpiar
-              </button>
-              <button
-                type="button"
-                onClick={handleApply}
-                className="w-full sm:w-auto px-6 py-2.5 rounded-xl bg-gray-800 text-white text-sm font-semibold transition-colors hover:bg-gray-900"
-                aria-label="Aplicar filtros"
-              >
-                Aplicar
-              </button>
+            <div className="flex flex-col gap-2">
+              <label className="text-xs text-secondary uppercase tracking-wide">Fin</label>
+              <div className="relative">
+                <input
+                  type="date"
+                  name="endDate"
+                  value={filters.endDate}
+                  onChange={handleInputChange}
+                  className="w-full rounded-lg border border-gray-200 py-2.5 pl-3 pr-10 text-sm focus:border-accent focus:outline-none focus:ring-2 focus:ring-accent/20"
+                  aria-label="Fecha de fin"
+                />
+                <FaCalendarAlt className="absolute right-3 top-1/2 -translate-y-1/2 text-gray-400 w-4 h-4" />
+              </div>
             </div>
           </div>
-        </Dialog.Content>
-      </Dialog.Portal>
-    </Dialog.Root>
+        </div>
+
+        <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+          <div className="flex flex-col gap-2">
+            <label className="text-sm font-medium text-primary">Tipo de mantenimiento</label>
+            <select
+              name="maintenanceType"
+              value={filters.maintenanceType}
+              onChange={handleInputChange}
+              className="w-full rounded-lg border border-gray-200 py-2.5 px-3 text-sm focus:border-accent focus:outline-none focus:ring-2 focus:ring-accent/20"
+              aria-label="Seleccionar tipo de mantenimiento"
+            >
+              <option value="">Todos</option>
+              {maintenanceTypes.map((type) => (
+                <option key={type} value={type}>{type}</option>
+              ))}
+            </select>
+          </div>
+
+          <div className="flex flex-col gap-2">
+            <label className="text-sm font-medium text-primary">Estado de la solicitud</label>
+            <select
+              name="status"
+              value={filters.status}
+              onChange={handleInputChange}
+              className="w-full rounded-lg border border-gray-200 py-2.5 px-3 text-sm focus:border-accent focus:outline-none focus:ring-2 focus:ring-accent/20"
+              aria-label="Seleccionar estado de la solicitud"
+            >
+              <option value="">Todos</option>
+              {statuses.map((status) => (
+                <option key={status} value={status}>{status}</option>
+              ))}
+            </select>
+          </div>
+        </div>
+      </div>
+    </FilterModal>
   )
 }
 

--- a/src/app/components/machinery/history/MaintenancePerformedFiltersModal.jsx
+++ b/src/app/components/machinery/history/MaintenancePerformedFiltersModal.jsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from 'react'
-import * as Dialog from '@radix-ui/react-dialog'
-import { FaTimes, FaCalendarAlt } from 'react-icons/fa'
+import { FaCalendarAlt } from 'react-icons/fa'
+import FilterModal from '@/app/components/shared/FilterModal'
 
 const defaultFilters = {
   startDate: '',
@@ -32,55 +32,47 @@ const MaintenancePerformedFiltersModal = ({
     onClear?.()
   }
 
-  return (
-    <Dialog.Root open={isOpen} onOpenChange={onClose}>
-      <Dialog.Portal>
-        <Dialog.Overlay className="fixed inset-0 bg-black/40 z-[60]" />
-        <Dialog.Content className="fixed top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 z-[70] w-full max-w-lg rounded-2xl card-theme p-6 space-y-6">
-          <div className="flex items-start justify-between">
-            <Dialog.Title className="text-xl font-semibold">Filtros</Dialog.Title>
-            <Dialog.Close asChild>
-              <button className="text-secondary hover:text-primary"><FaTimes /></button>
-            </Dialog.Close>
-          </div>
+  const handleApply = () => {
+    onApply?.(filters)
+  }
 
-          <div className="space-y-5">
-            <div className="space-y-3">
-              <span className="text-sm font-medium">Fecha de realización</span>
-              <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
-                <div className="flex flex-col gap-2">
-                  <label className="text-xs uppercase">Inicio</label>
-                  <div className="relative">
-                    <input type="date" name="startDate" value={filters.startDate} onChange={handleInputChange} className="input-theme pr-10" />
-                    <FaCalendarAlt className="absolute right-3 top-1/2 -translate-y-1/2 text-gray-400" />
-                  </div>
-                </div>
-                <div className="flex flex-col gap-2">
-                  <label className="text-xs uppercase">Fin</label>
-                  <div className="relative">
-                    <input type="date" name="endDate" value={filters.endDate} onChange={handleInputChange} className="input-theme pr-10" />
-                    <FaCalendarAlt className="absolute right-3 top-1/2 -translate-y-1/2 text-gray-400" />
-                  </div>
-                </div>
+  return (
+    <FilterModal
+      open={isOpen}
+      onClose={onClose}
+      onApply={handleApply}
+      onClear={handleClear}
+    >
+      <div className="space-y-5">
+        <div className="space-y-3">
+          <span className="text-sm font-medium">Fecha de realización</span>
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+            <div className="flex flex-col gap-2">
+              <label className="text-xs uppercase">Inicio</label>
+              <div className="relative">
+                <input type="date" name="startDate" value={filters.startDate} onChange={handleInputChange} className="input-theme pr-10" />
+                <FaCalendarAlt className="absolute right-3 top-1/2 -translate-y-1/2 text-gray-400" />
               </div>
             </div>
-
             <div className="flex flex-col gap-2">
-              <label className="text-sm font-medium">Técnico Asignado</label>
-              <select name="assignedTechnician" value={filters.assignedTechnician} onChange={handleInputChange} className="input-theme">
-                <option value="">Todos</option>
-                {technicians.map(tech => <option key={tech} value={tech}>{tech}</option>)}
-              </select>
+              <label className="text-xs uppercase">Fin</label>
+              <div className="relative">
+                <input type="date" name="endDate" value={filters.endDate} onChange={handleInputChange} className="input-theme pr-10" />
+                <FaCalendarAlt className="absolute right-3 top-1/2 -translate-y-1/2 text-gray-400" />
+              </div>
             </div>
           </div>
+        </div>
 
-          <div className="flex justify-end gap-3 pt-2">
-            <button onClick={handleClear} className="btn-error">Limpiar</button>
-            <button onClick={() => onApply(filters)} className="btn-primary">Aplicar</button>
-          </div>
-        </Dialog.Content>
-      </Dialog.Portal>
-    </Dialog.Root>
+        <div className="flex flex-col gap-2">
+          <label className="text-sm font-medium">Técnico Asignado</label>
+          <select name="assignedTechnician" value={filters.assignedTechnician} onChange={handleInputChange} className="input-theme">
+            <option value="">Todos</option>
+            {technicians.map(tech => <option key={tech} value={tech}>{tech}</option>)}
+          </select>
+        </div>
+      </div>
+    </FilterModal>
   )
 }
 

--- a/src/app/components/machinery/history/MaintenanceScheduledFiltersModal.jsx
+++ b/src/app/components/machinery/history/MaintenanceScheduledFiltersModal.jsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from 'react'
-import * as Dialog from '@radix-ui/react-dialog'
-import { FaTimes, FaCalendarAlt } from 'react-icons/fa'
+import { FaCalendarAlt } from 'react-icons/fa'
+import FilterModal from '@/app/components/shared/FilterModal'
 
 const defaultFilters = {
   startDate: '',
@@ -46,93 +46,61 @@ const MaintenanceScheduledFiltersModal = ({
     }
   }
 
-  const handleOpenChange = (open) => {
-    if (!open && typeof onClose === 'function') {
-      onClose()
-    }
-  }
-
   return (
-    <Dialog.Root open={isOpen} onOpenChange={handleOpenChange}>
-      <Dialog.Portal>
-        <Dialog.Overlay className="fixed inset-0 bg-black/40 backdrop-blur-sm z-[60]" />
-        <Dialog.Content className="fixed top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 z-[70] w-full max-w-lg rounded-2xl card-theme">
-          <div className="p-6 space-y-6">
-            <div className="flex items-start justify-between">
-              <div>
-                <Dialog.Title className="text-xl font-semibold text-primary">Filtros</Dialog.Title>
-              </div>
-              <Dialog.Close asChild>
-                <button
-                  onClick={onClose}
-                  className="text-secondary hover:text-primary"
-                  aria-label="Cerrar filtros"
-                >
-                  <FaTimes className="w-5 h-5" />
-                </button>
-              </Dialog.Close>
-            </div>
-
-            <div className="space-y-5">
-              <div className="space-y-3">
-                <span className="text-sm font-medium text-primary">Fecha programada</span>
-                <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
-                  {/* Date pickers for Start and End date */}
-                  <div className="flex flex-col gap-2">
-                    <label className="text-xs text-secondary uppercase tracking-wide">Inicio</label>
-                    <div className="relative">
-                      <input type="date" name="startDate" value={filters.startDate} onChange={handleInputChange} className="w-full rounded-lg border border-gray-200 py-2.5 pl-3 pr-10 text-sm focus:border-accent focus:outline-none focus:ring-2 focus:ring-accent/20" aria-label="Fecha de inicio"/>
-                      <FaCalendarAlt className="absolute right-3 top-1/2 -translate-y-1/2 text-gray-400 w-4 h-4" />
-                    </div>
-                  </div>
-                  <div className="flex flex-col gap-2">
-                    <label className="text-xs text-secondary uppercase tracking-wide">Fin</label>
-                    <div className="relative">
-                      <input type="date" name="endDate" value={filters.endDate} onChange={handleInputChange} className="w-full rounded-lg border border-gray-200 py-2.5 pl-3 pr-10 text-sm focus:border-accent focus:outline-none focus:ring-2 focus:ring-accent/20" aria-label="Fecha de fin"/>
-                      <FaCalendarAlt className="absolute right-3 top-1/2 -translate-y-1/2 text-gray-400 w-4 h-4" />
-                    </div>
-                  </div>
-                </div>
-              </div>
-
-              <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
-                <div className="flex flex-col gap-2">
-                  <label className="text-sm font-medium text-primary">Tipo de mantenimiento</label>
-                  <select name="maintenanceType" value={filters.maintenanceType} onChange={handleInputChange} className="w-full rounded-lg border border-gray-200 py-2.5 px-3 text-sm focus:border-accent focus:outline-none focus:ring-2 focus:ring-accent/20" aria-label="Seleccionar tipo de mantenimiento">
-                    <option value="">Todos</option>
-                    {maintenanceTypes.map((type) => (<option key={type} value={type}>{type}</option>))}
-                  </select>
-                </div>
-                <div className="flex flex-col gap-2">
-                  <label className="text-sm font-medium text-primary">Técnico Asignado</label>
-                  <select name="assignedTechnician" value={filters.assignedTechnician} onChange={handleInputChange} className="w-full rounded-lg border border-gray-200 py-2.5 px-3 text-sm focus:border-accent focus:outline-none focus:ring-2 focus:ring-accent/20" aria-label="Seleccionar técnico asignado">
-                    <option value="">Todos</option>
-                    {technicians.map((tech) => (<option key={tech} value={tech}>{tech}</option>))}
-                  </select>
-                </div>
-              </div>
-              
-              <div className="flex flex-col gap-2">
-                <label className="text-sm font-medium text-primary">Estado de la solicitud</label>
-                <select name="status" value={filters.status} onChange={handleInputChange} className="w-full rounded-lg border border-gray-200 py-2.5 px-3 text-sm focus:border-accent focus:outline-none focus:ring-2 focus:ring-accent/20" aria-label="Seleccionar estado">
-                  <option value="">Todos</option>
-                  {statuses.map((status) => (<option key={status} value={status}>{status}</option>))}
-                </select>
+    <FilterModal
+      open={isOpen}
+      onClose={onClose}
+      onApply={handleApply}
+      onClear={handleClear}
+    >
+      <div className="space-y-5">
+        <div className="space-y-3">
+          <span className="text-sm font-medium text-primary">Fecha programada</span>
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+            {/* Date pickers for Start and End date */}
+            <div className="flex flex-col gap-2">
+              <label className="text-xs text-secondary uppercase tracking-wide">Inicio</label>
+              <div className="relative">
+                <input type="date" name="startDate" value={filters.startDate} onChange={handleInputChange} className="w-full rounded-lg border border-gray-200 py-2.5 pl-3 pr-10 text-sm focus:border-accent focus:outline-none focus:ring-2 focus:ring-accent/20" aria-label="Fecha de inicio"/>
+                <FaCalendarAlt className="absolute right-3 top-1/2 -translate-y-1/2 text-gray-400 w-4 h-4" />
               </div>
             </div>
-
-            <div className="flex flex-col sm:flex-row sm:justify-end gap-3 pt-2">
-              <button type="button" onClick={handleClear} className="w-full sm:w-auto px-6 py-2.5 rounded-xl bg-red-600 text-white text-sm font-semibold transition-colors hover:bg-red-700" aria-label="Limpiar filtros">
-                Limpiar
-              </button>
-              <button type="button" onClick={handleApply} className="w-full sm:w-auto px-6 py-2.5 rounded-xl bg-gray-800 text-white text-sm font-semibold transition-colors hover:bg-gray-900" aria-label="Aplicar filtros">
-                Aplicar
-              </button>
+            <div className="flex flex-col gap-2">
+              <label className="text-xs text-secondary uppercase tracking-wide">Fin</label>
+              <div className="relative">
+                <input type="date" name="endDate" value={filters.endDate} onChange={handleInputChange} className="w-full rounded-lg border border-gray-200 py-2.5 pl-3 pr-10 text-sm focus:border-accent focus:outline-none focus:ring-2 focus:ring-accent/20" aria-label="Fecha de fin"/>
+                <FaCalendarAlt className="absolute right-3 top-1/2 -translate-y-1/2 text-gray-400 w-4 h-4" />
+              </div>
             </div>
           </div>
-        </Dialog.Content>
-      </Dialog.Portal>
-    </Dialog.Root>
+        </div>
+
+        <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+          <div className="flex flex-col gap-2">
+            <label className="text-sm font-medium text-primary">Tipo de mantenimiento</label>
+            <select name="maintenanceType" value={filters.maintenanceType} onChange={handleInputChange} className="w-full rounded-lg border border-gray-200 py-2.5 px-3 text-sm focus:border-accent focus:outline-none focus:ring-2 focus:ring-accent/20" aria-label="Seleccionar tipo de mantenimiento">
+              <option value="">Todos</option>
+              {maintenanceTypes.map((type) => (<option key={type} value={type}>{type}</option>))}
+            </select>
+          </div>
+          <div className="flex flex-col gap-2">
+            <label className="text-sm font-medium text-primary">Técnico Asignado</label>
+            <select name="assignedTechnician" value={filters.assignedTechnician} onChange={handleInputChange} className="w-full rounded-lg border border-gray-200 py-2.5 px-3 text-sm focus:border-accent focus:outline-none focus:ring-2 focus:ring-accent/20" aria-label="Seleccionar técnico asignado">
+              <option value="">Todos</option>
+              {technicians.map((tech) => (<option key={tech} value={tech}>{tech}</option>))}
+            </select>
+          </div>
+        </div>
+        
+        <div className="flex flex-col gap-2">
+          <label className="text-sm font-medium text-primary">Estado de la solicitud</label>
+          <select name="status" value={filters.status} onChange={handleInputChange} className="w-full rounded-lg border border-gray-200 py-2.5 px-3 text-sm focus:border-accent focus:outline-none focus:ring-2 focus:ring-accent/20" aria-label="Seleccionar estado">
+            <option value="">Todos</option>
+            {statuses.map((status) => (<option key={status} value={status}>{status}</option>))}
+          </select>
+        </div>
+      </div>
+    </FilterModal>
   )
 }
 

--- a/src/app/components/shared/FilterModal.jsx
+++ b/src/app/components/shared/FilterModal.jsx
@@ -1,5 +1,6 @@
 import { FaTimes } from "react-icons/fa";
 import React from "react";
+import * as Dialog from '@radix-ui/react-dialog';
 
 const FilterModal = ({
   open,
@@ -8,57 +9,49 @@ const FilterModal = ({
   onApply,
   children,
 }) => {
-
-  const handleBackdropClick = (e) => {
-    if (e.target === e.currentTarget) onClose();
-  };
-
-  if (!open) return null;
-
   return (
-    <div
-      className="fixed inset-0 bg-black/60 flex items-center justify-center z-50 p-4"
-      onClick={handleBackdropClick}
-      id="Filter Modal"
-    >
-      <div
-        className="bg-background rounded-xl shadow-2xl w-full max-w-2xl max-h-[95vh] overflow-hidden"
-        onClick={(e) => e.stopPropagation()}
-      >
-        {/* Header */}
-        <div className="flex items-center justify-between p-6 border-b border-gray-200">
-          <h2 className="text-xl font-bold text-gray-900 text-primary">
-            Filtrar por
-          </h2>
-          <button
-            aria-label="Cerrar modal"
-            onClick={onClose}
-            className="p-2 hover:bg-gray-100 rounded-full transition-colors cursor-pointer"
-          >
-            <FaTimes className="w-5 h-5 text-gray-500" />
-          </button>
-        </div>
-
-        {/* Campos personalizados */}
-        <div className="p-8">
-          {children}
-          <div className="flex gap-4 mt-8 justify-center">
-            <button
-              onClick={onClear}
-              className="flex-1 px-6 py-3 bg-red-500 text-white font-medium rounded-lg hover:bg-red-600 transition-colors parametrization-text"
-            >
-              Limpiar
-            </button>
-            <button
-              onClick={onApply}
-              className="flex-1 px-6 py-3 bg-black text-white font-medium rounded-lg hover:bg-gray-800 transition-colors parametrization-text"
-            >
-              Aplicar
-            </button>
+    <Dialog.Root open={open} onOpenChange={onClose}>
+      <Dialog.Portal>
+        <Dialog.Overlay className="fixed inset-0 bg-black/60 z-[60]" />
+        <Dialog.Content 
+          className="fixed top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 z-[70] bg-background rounded-xl shadow-2xl w-full max-w-2xl max-h-[95vh] overflow-hidden"
+        >
+          {/* Header */}
+          <div className="flex items-center justify-between p-6 border-b border-gray-200">
+            <Dialog.Title className="text-xl font-bold text-primary">
+              Filtrar por
+            </Dialog.Title>
+            <Dialog.Close asChild>
+              <button
+                aria-label="Cerrar modal"
+                className="p-2 hover:bg-gray-100 rounded-full transition-colors cursor-pointer"
+              >
+                <FaTimes className="w-5 h-5 text-gray-500" />
+              </button>
+            </Dialog.Close>
           </div>
-        </div>
-      </div>
-    </div>
+
+          {/* Campos personalizados */}
+          <div className="p-8">
+            {children}
+            <div className="flex gap-4 mt-8 justify-center">
+              <button
+                onClick={onClear}
+                className="flex-1 px-6 py-3 bg-red-500 text-white font-medium rounded-lg hover:bg-red-600 transition-colors parametrization-text"
+              >
+                Limpiar
+              </button>
+              <button
+                onClick={onApply}
+                className="flex-1 px-6 py-3 bg-black text-white font-medium rounded-lg hover:bg-gray-800 transition-colors parametrization-text"
+              >
+                Aplicar
+              </button>
+            </div>
+          </div>
+        </Dialog.Content>
+      </Dialog.Portal>
+    </Dialog.Root>
   );
 };
 


### PR DESCRIPTION
This pull request refactors the modal filter components for machinery history to use a new shared `FilterModal` component, improving code consistency and maintainability. Additionally, the coding style guide is updated to document the shared components and clarify their required usage, along with reorganizing and renumbering its sections for better structure.

**Component Refactoring:**

* All machinery history filter modals (`HistoryFiltersModal.jsx`, `MaintenanceFiltersModal.jsx`, `MaintenancePerformedFiltersModal.jsx`, `MaintenanceScheduledFiltersModal.jsx`) now use the shared `FilterModal` instead of duplicating Radix UI dialog code, reducing repetition and ensuring a consistent user experience. [[1]](diffhunk://#diff-01af51951ca40d5691764d098400e1863b0566a815d0ab57f3ba89c80baa0493L2-R3) [[2]](diffhunk://#diff-01af51951ca40d5691764d098400e1863b0566a815d0ab57f3ba89c80baa0493L47-L73) [[3]](diffhunk://#diff-01af51951ca40d5691764d098400e1863b0566a815d0ab57f3ba89c80baa0493L134-R114) [[4]](diffhunk://#diff-e8920b13dbb3ee9fb07149bda6105c720aac515e05e56e27cadd8dc5fbb591b3L2-R3) [[5]](diffhunk://#diff-e8920b13dbb3ee9fb07149bda6105c720aac515e05e56e27cadd8dc5fbb591b3L47-L73) [[6]](diffhunk://#diff-e8920b13dbb3ee9fb07149bda6105c720aac515e05e56e27cadd8dc5fbb591b3L143-R123) [[7]](diffhunk://#diff-f7b6dbb02628998fb6d4bbec9853e3d4a914ca776ae7fb04ced552984ec139b6L2-R3) [[8]](diffhunk://#diff-f7b6dbb02628998fb6d4bbec9853e3d4a914ca776ae7fb04ced552984ec139b6L35-R45) [[9]](diffhunk://#diff-f7b6dbb02628998fb6d4bbec9853e3d4a914ca776ae7fb04ced552984ec139b6L76-R75) [[10]](diffhunk://#diff-b2146008ec670d8284bd768482b7effc7fb5b63be4c39b409dbbdebe760442c6L2-R3) [[11]](diffhunk://#diff-b2146008ec670d8284bd768482b7effc7fb5b63be4c39b409dbbdebe760442c6L49-L75) [[12]](diffhunk://#diff-b2146008ec670d8284bd768482b7effc7fb5b63be4c39b409dbbdebe760442c6L123-R103)

* The new shared `FilterModal.jsx` is implemented using Radix UI's dialog primitives, supporting custom fields and actions, and is now the standard for all filter modals. [[1]](diffhunk://#diff-7d647f80ef45bcaa8ac0f898ea5c71bcc23df9094c10c12a9401f154f7baa6a8R3) [[2]](diffhunk://#diff-7d647f80ef45bcaa8ac0f898ea5c71bcc23df9094c10c12a9401f154f7baa6a8L11-R31) [[3]](diffhunk://#diff-7d647f80ef45bcaa8ac0f898ea5c71bcc23df9094c10c12a9401f154f7baa6a8L60-R54)

**Coding Style Guide Updates:**

* Added a comprehensive section documenting shared components (`SuccessErrorModal`, `TableList`, `FilterModal`) with mandatory usage instructions, props, and guidelines for when to use Radix UI directly.

* Reorganized and renumbered sections in the coding style guide for clarity (e.g., "Estilos y Temas" is now section 6, "Manejo de Estado" is 7, etc.), reflecting the new documentation structure. [[1]](diffhunk://#diff-d499b8cc52e0995d4c8e472ffb3de45a0449c3984f3ca96774ff1feceb8628ecL123-R179) [[2]](diffhunk://#diff-d499b8cc52e0995d4c8e472ffb3de45a0449c3984f3ca96774ff1feceb8628ecL154-R218) [[3]](diffhunk://#diff-d499b8cc52e0995d4c8e472ffb3de45a0449c3984f3ca96774ff1feceb8628ecL178-R227)